### PR TITLE
Add tests and CI with flake8

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,23 @@
+name: CI
+
+on: [push, pull_request]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.10']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt -r requirements-dev.txt
+      - name: Flake8
+        run: flake8
+      - name: Run tests
+        run: pytest

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest
+flake8

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,0 +1,45 @@
+import datetime
+from types import SimpleNamespace
+
+import pytz
+from django.conf import settings
+
+from dj_rest_kit import helpers, constants
+
+if not settings.configured:
+    settings.configure(TIME_ZONE="UTC", USE_TZ=True)
+
+
+def test_get_user_timezone_from_request():
+    request = SimpleNamespace(headers={"timezone": "Asia/Kolkata"})
+    assert helpers.get_user_timezone_from_request(request) == "Asia/Kolkata"
+
+
+def test_get_user_timezone_from_request_default():
+    request = SimpleNamespace(headers={})
+    assert helpers.get_user_timezone_from_request(request) == "UTC"
+
+
+def test_convert_to_utc_and_back():
+    tz = pytz.timezone("Asia/Kolkata")
+    aware = tz.localize(datetime.datetime(2023, 1, 1, 8, 30))
+    utc_dt = helpers.convert_to_utc(aware)
+    assert utc_dt.tzinfo == pytz.UTC
+    converted = helpers.convert_to_user_timezone(utc_dt, user_timezone="Asia/Kolkata")
+    assert converted == aware
+
+
+def test_convert_to_formatted_user_timezone():
+    tz = pytz.timezone("Asia/Kolkata")
+    aware = tz.localize(datetime.datetime(2023, 1, 1, 8, 30))
+    utc_dt = helpers.convert_to_utc(aware)
+    formatted = helpers.convert_to_formatted_user_timezone(utc_dt, user_timezone="Asia/Kolkata")
+    assert formatted == aware.strftime(constants.DateTimeFormat.DATE_TIME)
+
+
+def test_convert_user_datetime_str_to_utc():
+    result = helpers.convert_user_datetime_str_to_utc("2023-01-01 08:30", "Asia/Kolkata")
+    tz = pytz.timezone("Asia/Kolkata")
+    aware = tz.localize(datetime.datetime(2023, 1, 1, 8, 30))
+    expected = helpers.convert_to_utc(aware)
+    assert result == expected

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -1,0 +1,30 @@
+from rest_framework.test import APIRequestFactory
+
+from dj_rest_kit.pagination import CustomPagination
+
+
+def test_paginate_queryset_limit_offset():
+    factory = APIRequestFactory()
+    request = factory.get('/', {'limit': 2, 'offset': 0})
+    paginator = CustomPagination()
+    data = list(range(5))
+    page = paginator.paginate_queryset(data, request)
+    assert page == data[:2]
+
+
+def test_paginate_queryset_all():
+    factory = APIRequestFactory()
+    request = factory.get('/', {'limit': 'all'})
+    paginator = CustomPagination()
+    data = list(range(5))
+    page = paginator.paginate_queryset(data, request)
+    assert page == data
+
+
+def test_paginate_queryset_offset_beyond_length():
+    factory = APIRequestFactory()
+    request = factory.get('/', {'limit': 2, 'offset': 10})
+    paginator = CustomPagination()
+    data = list(range(5))
+    page = paginator.paginate_queryset(data, request)
+    assert page == []


### PR DESCRIPTION
## Summary
- add helper and pagination unit tests
- add requirements-dev with pytest and flake8
- run flake8 and tests in GitHub Actions

## Testing
- `pip install -r requirements.txt -r requirements-dev.txt` *(fails: Could not find a version that satisfies the requirement django-filter==23.5)*
- `flake8` *(fails: command not found)*
- `pytest -q` *(fails: command not found)*